### PR TITLE
- changed to self-contained dockers. Just run docker-compose up

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,5 @@
 TEMPLATE_NAME ?= janus
 
-run: image
-	@docker run -it -p 8188:8188 -p 8189:8189 -p 6000:6000/udp -p 6001:6001/udp -p 6002:6002/udp $(TEMPLATE_NAME)
-
-shell: image
-	@docker run -it -p 8188:8188 -p 8189:8189 -p 6000:6000/udp -p 6001:6001/udp -p 6002:6002/udp $(TEMPLATE_NAME) /bin/bash
-
-image:
-	@docker build -t $(TEMPLATE_NAME) .
+run-demo:
+	docker-compose up
+	@echo "open brower at http://localhost:8000 port"

--- a/README.md
+++ b/README.md
@@ -4,12 +4,8 @@ Run up a [janus-gateway](https://github.com/meetecho/janus-gateway) instance usi
 
 ## Streaming test
 
-1. Install docker and GStreamer 1.0.
+1. install docker-compose
+2. run `docker-compose up`
+3. open browser at http://localhost:8000
 
-2. Build this image with `make image`
-
-3. Run the Janus server with `make run`.  This will forward some ports: 8088/tcp (HTTP), 8188/tcp (WebSocket), 6000/udp (RTP)
-
-4. Run `./gst_test.sh` to start sending RTP to Janus.
-
-5. Start an HTTP server in `webapps/` and browse to the index.  You should see a test pattern.
+you should see a test pattern

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,17 @@
+version: '3.1'
+services:
+    webapp:
+        image: python:3.9
+        ports:
+            - "8000:8000"
+        command: python3 -m http.server --directory=/webapp
+        volumes:
+            - ./webapp:/webapp
+    janus:
+        build: .
+        ports:
+            - "8188:8188"
+            - "8189:8189"
+            - "6000-6002:6000-6002/udp"
+    videosrc:
+        build: gst_test

--- a/gst_test/Dockerfile
+++ b/gst_test/Dockerfile
@@ -1,10 +1,9 @@
 FROM ubuntu:20.04
 
-
-RUN apt-get update -y  # TODO: merge it with rest of commands
-RUN apt-get install -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-rtp
-RUN apt-get install -y gstreamer1.0-tools
-# TODO: cleanup of files
+RUN apt-get update -y && \
+    apt-get install -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-rtp \
+                       gstreamer1.0-tools  && \
+    apt-get clean -y
 
 
 ADD run.sh /run.sh

--- a/gst_test/Dockerfile
+++ b/gst_test/Dockerfile
@@ -1,0 +1,12 @@
+FROM ubuntu:20.04
+
+
+RUN apt-get update -y  # TODO: merge it with rest of commands
+RUN apt-get install -y gstreamer1.0-plugins-good gstreamer1.0-plugins-bad gstreamer1.0-plugins-ugly gstreamer1.0-plugins-rtp
+RUN apt-get install -y gstreamer1.0-tools
+# TODO: cleanup of files
+
+
+ADD run.sh /run.sh
+
+CMD /run.sh

--- a/gst_test/run.sh
+++ b/gst_test/run.sh
@@ -10,4 +10,4 @@ gst-launch-1.0 -v videotestsrc is-live=true \
 ! queue \
 ! vp8enc deadline=33333 cpu-used=16 target-bitrate=$BITRATE keyframe-max-dist=90 max-quantizer=24 \
 ! rtpvp8pay \
-! udpsink host=127.0.0.1 port=6000 sync=false qos=true
+! udpsink host=janus port=6000 sync=false qos=true


### PR DESCRIPTION
I thought that it would be easier for someone who is googling about janus, if he can run demo with one click. 

It's  first demo of Janus that actually works (among those I googled today)